### PR TITLE
Pinned botocore version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,7 @@ setup_dict = dict(
         'keyring==9.1',
         'boto3==1.4.4',
         'awscli==1.11.38',
+        'botocore==1.5.1',
         'configparser==3.5.0b2'
     ] + python_version_specific_requires,
     # Allow tests to be run with `python setup.py test'.


### PR DESCRIPTION
The currently pinned awscli version requires botocore 1.5.1. 