### PR TITLE
check the config before saving the password in the local keychain

### DIFF
--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.7.0.post2'
+version = '0.7.0.post3'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -263,7 +263,8 @@ class S3Keyring(S3Backed, KeyringBackend):
         # We also save the password in the local OS keyring. This will allow us
         # to retrieve the password locally if the S3 bucket would not be
         # available.
-        keyring.set_password(service, username, password)
+        if self.use_local_keyring:
+            keyring.set_password(service, username, password)
 
     def delete_value(self, *args, **kwargs):
         """An alias for delete_password"""


### PR DESCRIPTION
Right now it doesn't check the `keyring.ini` config file before saving the value in the local keychain. This PR adds a check before doing that.