### PR TITLE
Add content-type header text/plain to passwords

### DIFF
--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.7.1.post0'
+version = '0.7.1.post1'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero']
 authors_string = ', '.join(authors)

--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -249,9 +249,13 @@ class S3Keyring(S3Backed, KeyringBackend):
         # Save in S3 using both server and client side encryption
         keyname = self._get_s3_key(service, username)
         try:
-            self.bucket.Object(keyname).put(ACL='private', Body=pwd_base64,
-                                            ServerSideEncryption='aws:kms',
-                                            SSEKMSKeyId=self.kms_key_id)
+            self.bucket.Object(keyname).put(
+                ACL='private',
+                Body=pwd_base64,
+                ServerSideEncryption='aws:kms',
+                SSEKMSKeyId=self.kms_key_id,
+                ContentType='text/plain'
+            )
         except EndpointConnectionError:
             if self.use_local_keyring:
                 # Can't connect to S3: fallback to OS keyring


### PR DESCRIPTION
This is to allow the terraform data source `aws_s3_bucket_object ` to retrieve s3 objects by adding the `content-type` header to the value of `text/plain`