### PR TITLE
Update click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ipython
 configparser==3.5.0b2
 
 # Cli
-Click==5.1
+Click>=5.1
 
 # Improved debugger
 pdbpp


### PR DESCRIPTION
This is to update the Click dependency. This matches the [upstream version](https://github.com/FindHotel/s3keyring/blob/master/setup.py).

This is to resolve this error I am getting using s3keyring with black
```
ERROR: Cannot install Click==7.0, -r /requirements.txt (line 21) and -r /requirements.txt (line 28) because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested Click==7.0
    black 19.3b0 depends on click>=6.5
    s3keyring 0.6.0.post4 depends on click==5.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```
