### PR TITLE
Updating keyring for 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ Paver==1.2.1
 colorama==0.2.7
 ipython
 configparser==3.5.0b2
+keyring==19.2.0
 
 # Cli
 Click==5.1

--- a/setup.py
+++ b/setup.py
@@ -257,7 +257,7 @@ setup_dict = dict(
     package_data = {'': ['*.ini']},
     install_requires=[
         'click>=5.1',
-        'keyring==9.1',
+        'keyring==19.2.0',
         'boto3>=1.4.4',
         'awscli>=1.11.38',
         'botocore>=1.5.1',


### PR DESCRIPTION
Due to issues with Callable and the old version of keyring being pinned at 9.1, we need to update to work with newer versions of python.