### PR TITLE
Install different keyring version depending on python version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,8 @@ Paver==1.2.1
 colorama==0.2.7
 ipython
 configparser==3.5.0b2
-keyring==19.2.0
+keyring==19.2.0;python_version>='3.0'
+keyring==9.1;python_version<'3.0'
 
 # Cli
 Click==5.1

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.8.0.post6'
+version = '0.8.0.post7'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero', 'Adroll']
 authors_string = ', '.join(authors)

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,10 @@ python_version_specific_requires = []
 # the Python standard library, otherwise we install it as a separate package
 if sys.version_info < (2, 7) or (3, 0) <= sys.version_info < (3, 3):
     python_version_specific_requires.append('argparse')
+if (2, 7) <= sys.version_info < (3, 0):
+    python_version_specific_requires.append('keyring==9.1')
+elif sys.version_info >= (3, 0):
+    python_version_specific_requires.append('keyring==19.2.0')
 
 
 # See here for more options:
@@ -257,7 +261,6 @@ setup_dict = dict(
     package_data = {'': ['*.ini']},
     install_requires=[
         'click>=5.1',
-        'keyring==19.2.0',
         'boto3>=1.4.4',
         'awscli>=1.11.38',
         'botocore>=1.5.1',


### PR DESCRIPTION
since keyring `19.2.0` works only for `python > 3` install `9.1` when in `python 2` envs

- create a tar.gz via `python setup.py sdist bdist_wheel` 
- copy the file in your target repo
- install it via `pip install xxx.tar.gz`
- verify that no new version of keyring is installed and that `19.2.0` is not