### PR TITLE
[SCL-1667] Consolidate click dependency and fix build-cache error handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -218,9 +218,9 @@ allows for applications to pull down a single cache file instead of many
 individual passwords to speed up launch times::
 
   # Update cache
-  s3keyring build_cache
+  s3keyring build-cache
   # Retrieve cache
-  s3keyring get_cache
+  s3keyring get-cache
 
 
 .. _keyring module: https://pypi.python.org/pypi/keyring

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -70,10 +70,11 @@ def delete(ctx, service, username):
 
 
 @main.command()
+@click.option('--strict/--no-strict', default=False)
 @click.pass_context
-def build_cache(ctx):
+def build_cache(ctx, strict):
     """Builds cache for a namespace"""
-    click.echo(ctx.obj['keyring'].build_cache())
+    click.echo(ctx.obj['keyring'].build_cache(strict=strict))
 
 
 @main.command()

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -70,10 +70,12 @@ def delete(ctx, service, username):
 
 
 @main.command()
+@click.option('--strict/--no-strict', default=True)
+@click.option('--dry-run/--no-dry-run', default=False)
 @click.pass_context
-def build_cache(ctx):
+def build_cache(ctx, strict, dry_run):
     """Builds cache for a namespace"""
-    click.echo(ctx.obj['keyring'].build_cache())
+    click.echo(ctx.obj['keyring'].build_cache(strict=strict, dry_run=dry_run))
 
 
 @main.command()

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -70,12 +70,10 @@ def delete(ctx, service, username):
 
 
 @main.command()
-@click.option('--strict/--no-strict', default=True)
-@click.option('--dry-run/--no-dry-run', default=False)
 @click.pass_context
-def build_cache(ctx, strict, dry_run):
+def build_cache(ctx):
     """Builds cache for a namespace"""
-    click.echo(ctx.obj['keyring'].build_cache(strict=strict, dry_run=dry_run))
+    click.echo(ctx.obj['keyring'].build_cache())
 
 
 @main.command()

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -70,8 +70,8 @@ def delete(ctx, service, username):
 
 
 @main.command()
-@click.option('--strict/--no-strict', default=True)
-@click.option('--dry-run/--no-dry-run', default=False)
+@click.option('--strict/--no-strict', default=True, help="Whether to abort on first failure or to skip and move on instead")
+@click.option('--dry-run/--no-dry-run', default=False, help="Only collect secrets without uploading cache file")
 @click.pass_context
 def build_cache(ctx, strict, dry_run):
     """Builds cache for a namespace"""

--- a/s3keyring/cli.py
+++ b/s3keyring/cli.py
@@ -70,8 +70,8 @@ def delete(ctx, service, username):
 
 
 @main.command()
-@click.option('--strict/--no-strict', default=True, help="Whether to abort on first failure or to skip and move on instead")
-@click.option('--dry-run/--no-dry-run', default=False, help="Only collect secrets without uploading cache file")
+@click.option('--strict/--no-strict', default=True)
+@click.option('--dry-run/--no-dry-run', default=False)
 @click.pass_context
 def build_cache(ctx, strict, dry_run):
     """Builds cache for a namespace"""

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.9.0'
+version = '0.10.0'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero', 'Adroll']
 authors_string = ', '.join(authors)

--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -313,7 +313,7 @@ class S3Keyring(S3Backed, KeyringBackend):
             print("WARNING: {}/{} not found in OS keyring".format(
                 service, username))
 
-    def build_cache(self):
+    def build_cache(self, strict=False):
         """Builds the cache file for the namespace"""
         cache = defaultdict(dict)
 
@@ -346,7 +346,7 @@ class S3Keyring(S3Backed, KeyringBackend):
         # write the cache file to S3
         key = CACHE_KEY.format(self.namespace)
 
-        if has_errors:
+        if has_errors and strict:
             raise Exception("Unable to fetch some secrets, refusing to update {}".format(key))
 
         json_contents = json.dumps(cache)

--- a/s3keyring/s3.py
+++ b/s3keyring/s3.py
@@ -313,7 +313,7 @@ class S3Keyring(S3Backed, KeyringBackend):
             print("WARNING: {}/{} not found in OS keyring".format(
                 service, username))
 
-    def build_cache(self, strict=True, dry_run=False):
+    def build_cache(self):
         """Builds the cache file for the namespace"""
         cache = defaultdict(dict)
 
@@ -335,12 +335,6 @@ class S3Keyring(S3Backed, KeyringBackend):
             except Exception as e:
                 print('Failed to add key "' + obj.key + '" to cache:')
                 print(e)
-                if strict:
-                    # enforce that cache be updated with full list of secrets
-                    # found or not updated at all
-                    raise
-                print('Skipped "' + obj.key + '" from cache')
-                continue
 
             # Add to the cache
             cache[service][username] = password
@@ -348,10 +342,9 @@ class S3Keyring(S3Backed, KeyringBackend):
         # write the cache file to S3
         key = CACHE_KEY.format(self.namespace)
         json_contents = json.dumps(cache)
-        if not dry_run:
-            self.bucket.Object(key).put(ACL='private', Body=json_contents,
-                                        ServerSideEncryption='aws:kms',
-                                        SSEKMSKeyId=self.kms_key_id)
+        self.bucket.Object(key).put(ACL='private', Body=json_contents,
+                                    ServerSideEncryption='aws:kms',
+                                    SSEKMSKeyId=self.kms_key_id)
 
     def get_cache(self):
         key = CACHE_KEY.format(self.namespace)

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ setup_dict = dict(
     # Include the s3keyring.ini file in the package root dir
     package_data = {'': ['*.ini']},
     install_requires=[
-        'click>=5.1',
+        'click>=7,<9',
         'keyring==9.1;python_version<\'3\'',
         'keyring==19.2.0;python_version>=\'3\'',
         'boto3>=1.4.4',


### PR DESCRIPTION
click>=7 introduces a breaking change where underscores in functions become dashes in the corresponding CLI command (so a function `build_cache` must be invoked via the CLI `build-cache` command).
What's in this PR:
- bump the minimum version for click dependency from `>=5` to `>=7`
- also add an upper-bound to prevent similar issues from happening again (version 8.x was included in the range because it doesn't seem to include breaking changes that would affect s3keyring)
- update README to reflect the usage of dashes in CLI command(s)
- Fix `build_cache` error logic: currently if one of the secrets fail to be fetched/parsed (notably due to utf-8 decoding errors) either the execution crashes with an `UnboundLocalError` (if this occurs when processing the first secret) or the secret is assigned the value from the previous loop iteration (i.e the content of the secret processed just before the one failing)
- Add a `--strict` flag to raise an error instead of updating the s3 json cache file in case of errors (defaults to False). NOTE: the error is raised after looping through all the secrets so that all the failed secrets are printed before failing (which helps the user to troubleshoot all secrets instead of having to fix them one by one)