### PR TITLE
[NWA-3063] Use `importlib` to Python3.12 compatibility

### DIFF
--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.11.0'
+version = '0.11.0a1'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero', 'Adroll']
 authors_string = ', '.join(authors)

--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.10.0'
+version = '0.11.0'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero', 'Adroll']
 authors_string = ', '.join(authors)

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,14 @@ import os
 import sys
 if sys.version_info[0] == 2:
     import imp
+    from distutils import spawn
 else:
+    import shutil
     import importlib.machinery
     import importlib.util
 import subprocess
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
-from distutils import spawn
 
 
 # Python 2.6 subprocess.check_output compatibility. Thanks Greg Hewgill!
@@ -43,6 +44,21 @@ CODE_DIRECTORY = 's3keyring'
 DOCS_DIRECTORY = 'docs'
 TESTS_DIRECTORY = 'tests'
 PYTEST_FLAGS = ['--doctest-modules']
+
+def find_executable(executable):
+    """Find an executable in the PATH.
+
+    :param executable: the executable to find
+    :type executable: :class:`str`
+    :
+    :return: the path to the executable
+    :rtype: :class:`str`
+    """
+    if sys.version_info[0] == 2:
+        return spawn.find_executable(executable)
+    else:
+        return shutil.which(executable)
+
 
 # https://docs.python.org/3/whatsnew/3.12.html#:~:text=Replace%20imp.load_source()%20with%3A
 def load_source(modname, filename):
@@ -102,7 +118,7 @@ def is_git_project():
 
 
 def has_git():
-    return bool(spawn.find_executable("git"))
+    return bool(find_executable("git"))
 
 
 def get_git_project_files():


### PR DESCRIPTION
Jira ticket: https://adroll.atlassian.net/browse/NWA-3063

Adds the usage of `importlib` to python 3 while python2 will continue to use `imp`