### PR TITLE
Fix setup.cfg metadata parameter name

### DIFF
--- a/s3keyring/metadata.py
+++ b/s3keyring/metadata.py
@@ -8,7 +8,7 @@ Information describing the project.
 package = 's3keyring'
 project = "S3 backend for the keyring module"
 project_no_spaces = project.replace(' ', '')
-version = '0.11.0'
+version = '0.11.1'
 description = 'Keeps your secrets safe in S3'
 authors = ['German Gomez-Herrero', 'Adroll']
 authors_string = ', '.join(authors)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
## Summary
- Fixed the hyphenated parameter name `description-file` to use underscore `description_file` in setup.cfg
- This was causing errors in setuptools 78

## Test plan
- Verify package builds correctly with the fixed parameter name

🤖 Generated with [Claude Code](https://claude.ai/code)